### PR TITLE
fix: default export using namespace

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ import { Readable } from 'node:stream'
 
 const kLayout = Symbol('fastifyHtmlLayout')
 
-export default fp(async (fastify, opts) => {
+function plugin (fastify, opts) {
   fastify.decorate('html', opts.async ? htmlAsyncGenerator : html)
   fastify.decorate(kLayout, null)
 
@@ -40,6 +40,11 @@ export default fp(async (fastify, opts) => {
     this.send(opts.async ? Readable.from(htmlString) : htmlString)
     return this
   })
-}, {
+}
+
+const fastifyHtml = fp(plugin, {
+  fastify: '5.x',
   name: 'fastify-html'
 })
+
+export default fastifyHtml

--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -30,11 +30,16 @@ declare module 'fastify' {
   }
 }
 
-interface FastifyHtmlPluginOptions {
-  async?: boolean;
+type FastifyHtmlPlugin = FastifyPluginCallback<fastifyHtml.FastifyHtmlPluginOptions>;
+
+declare namespace fastifyHtml {
+  export const fastifyHtml: FastifyHtmlPlugin;
+
+  export interface FastifyHtmlPluginOptions {
+    async?: boolean;
+  }
+  
+  export { fastifyHtml as default }
 }
 
-type FastifyHtmlPlugin = FastifyPluginCallback<FastifyHtmlPluginOptions>;
-
-declare const fastifyHtml: FastifyHtmlPlugin;
 export = fastifyHtml;

--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -30,16 +30,19 @@ declare module 'fastify' {
   }
 }
 
-type FastifyHtmlPlugin = FastifyPluginCallback<fastifyHtml.FastifyHtmlPluginOptions>;
+type FastifyHtmlPlugin = FastifyPluginCallback<fastifyHtml.FastifyHtmlOptions>;
 
 declare namespace fastifyHtml {
-  export const fastifyHtml: FastifyHtmlPlugin;
-
-  export interface FastifyHtmlPluginOptions {
+  export interface FastifyHtmlOptions {
     async?: boolean;
   }
   
+  export const fastifyHtml: FastifyHtmlPlugin;
   export { fastifyHtml as default }
 }
+
+declare function fastifyHtml (
+  ...params: Parameters<FastifyHtmlPlugin>
+): ReturnType<FastifyHtmlPlugin>
 
 export = fastifyHtml;


### PR DESCRIPTION
This fixes #24 and export FastifyHtmlPluginOptions.

Everything is in a namespace and therefore it should still work with commonjs.

I was inspired by [@fastify/fastify](https://github.com/fastify/fastify/blob/main/fastify.d.ts) and [@fastify/fastify-cookie](https://github.com/fastify/fastify-cookie/blob/main/types/plugin.d.ts) to write this fix.

Note: this is my very first contribution to someone else's code repository, I hope that I did it correctly. If there is something wrong or anything missing, tell me what and I will do my best to handle it.